### PR TITLE
Scripts are now POSIX-compliant. Successful compilation on BSD

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,18 +1,17 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 SOURCE=$(find . -type f ! -path './test/*' -name "*.c")
-if [ "$(uname)" == "Darwin" ]; then
 HEADER="-I. -I/usr/local/include"
-LIBS="-L/usr/local/lib -lz -liconv -lprinthex"
+if [ "$(uname)" = "Linux" ]; then
+    LIBS="-L/usr/local/lib -lprinthex -lz"
 else
-HEADER="-I."
-LIBS="-lprinthex -lz"
+    LIBS="-L/usr/local/lib -lz -liconv -lprinthex"
 fi
 VERSION=$(head -n1 CHANGELOG | cut -d ' ' -f 1)
 
 for c in $SOURCE ;
 do    
-    echo -e "\e[1;34mCompiling $c …\e[0m"
+    printf "\033[1;34mCompiling $c …\033[0m\n"
     clang -DxDEBUG -DVERSION="\"$VERSION\"" -Wno-multichar --std=gnu99 $HEADER -O2 -g -c -o "${c%.*}.o" $c
 done
 

--- a/id3dump
+++ b/id3dump
@@ -1,15 +1,15 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 ID3EDIT="id3edit"
-ARG="$1"
-FILE="$2"
+ARG=$1
+FILE=$2
 
-if [ "$ARG" == "--help" ] || [ "$ARG" == "-h" ] ; then
+if [ "$ARG" = "--help" -o "$ARG" = "-h" ]; then
     $ID3EDIT --help
     exit 0
 fi
 
-if [ "$ARG" == "--version" ] || [ "$ARG" == "-v" ] ; then
+if [ "$ARG" = "--version" -o "$ARG" = "-v" ]; then
     $ID3EDIT --version
     exit 0
 fi

--- a/id3frames
+++ b/id3frames
@@ -1,14 +1,14 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 ID3EDIT="id3edit"
 ARG="$1"
 
-if [ "$ARG" == "--help" ] || [ "$ARG" == "-h" ] ; then
+if [ "$ARG" = "--help" -o "$ARG" = "-h" ]; then
     $ID3EDIT --help
     exit 0
 fi
 
-if [ "$ARG" == "--version" ] || [ "$ARG" == "-v" ] ; then
+if [ "$ARG" = "--version" -o "$ARG" = "-v" ]; then
     $ID3EDIT --version
     exit 0
 fi

--- a/id3show
+++ b/id3show
@@ -1,14 +1,14 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 ID3EDIT="id3edit"
 ARG="$1"
 
-if [ "$ARG" == "--help" ] || [ "$ARG" == "-h" ] ; then
+if [ "$ARG" = "--help" -o "$ARG" = "-h" ]; then
     $ID3EDIT --help
     exit 0
 fi
 
-if [ "$ARG" == "--version" ] || [ "$ARG" == "-v" ] ; then
+if [ "$ARG" = "--version" -o "$ARG" = "-v" ]; then
     $ID3EDIT --version
     exit 0
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 INSTALLPATH=/usr/local/bin
 
 for SOURCE in id3edit id3show id3frames id3dump ; do
-    install -m 755 -v -g root -o root $SOURCE $INSTALLPATH
+    install -m 755 -v -o root $SOURCE $INSTALLPATH
 done
 
 strip $INSTALLPATH/id3edit


### PR DESCRIPTION
I changed shebang from #!/usr/bin/env bash to #!/bin/sh and make the scripts independent of bash
Now, the build.sh works on any POSIX Shell